### PR TITLE
Example of lazy-fetching impl

### DIFF
--- a/src/main/java/ua/rbolck/rader/dao/PostDAOImpl.java
+++ b/src/main/java/ua/rbolck/rader/dao/PostDAOImpl.java
@@ -8,8 +8,6 @@ import java.io.IOException;
 import java.sql.*;
 import java.util.Collection;
 
-import static ua.rbolck.rader.dao.UserDAOImpl.getUserbyId;
-
 public class PostDAOImpl implements PostDAOI {
 
     private static final Logger log = Logger.getLogger(PostDAOImpl.class);

--- a/src/main/java/ua/rbolck/rader/dao/PostDAOImpl.java
+++ b/src/main/java/ua/rbolck/rader/dao/PostDAOImpl.java
@@ -30,7 +30,7 @@ public class PostDAOImpl implements PostDAOI {
             try (ResultSet resultSet = ps.executeQuery()) {
                 if (resultSet.next()) {
                     post = new Post(resultSet.getInt(1), resultSet.getString(3), resultSet.getString(4),
-                            resultSet.getInt(5), resultSet.getInt(6), getUserbyId(resultSet.getInt(7)),
+                            resultSet.getInt(5), resultSet.getInt(6), resultSet.getInt(7),
                             resultSet.getTimestamp(8));
 
                     log.info("Get " + post.toString());
@@ -55,7 +55,7 @@ public class PostDAOImpl implements PostDAOI {
                 log.info("Get posts:");
                 while (resultSet.next()) {
                     post = new Post(resultSet.getInt(1), resultSet.getString(3), resultSet.getString(4),
-                            resultSet.getInt(5), resultSet.getInt(6), getUserbyId(resultSet.getInt(7)),
+                            resultSet.getInt(5), resultSet.getInt(6), resultSet.getInt(7),
                             resultSet.getTimestamp(8));
                     log.info(post.toString());
                     posts.add(post);
@@ -81,7 +81,7 @@ public class PostDAOImpl implements PostDAOI {
                 log.info("Get last " + limit + " posts:");
                 while (resultSet.next()) {
                     post = new Post(resultSet.getInt(1), resultSet.getString(3), resultSet.getString(4),
-                            resultSet.getInt(5), resultSet.getInt(6), getUserbyId(resultSet.getInt(7)),
+                            resultSet.getInt(5), resultSet.getInt(6), resultSet.getInt(7),
                             resultSet.getTimestamp(8));
 
                     log.info(post.toString());

--- a/src/main/java/ua/rbolck/rader/dao/UserDAOImpl.java
+++ b/src/main/java/ua/rbolck/rader/dao/UserDAOImpl.java
@@ -21,10 +21,6 @@ public class UserDAOImpl implements UserDAOI {
 
     @Override
     public User get(int id) {
-        return getUserbyId(id);
-    }
-
-    public static User getUserbyId(int id) {
         User user = null;
         try (DatabaseConnection db = DatabaseConnection.getInstance();
              Connection connection = db.getConnection();

--- a/src/main/java/ua/rbolck/rader/entity/Post.java
+++ b/src/main/java/ua/rbolck/rader/entity/Post.java
@@ -32,7 +32,7 @@ public class Post {
         this.content = content;
         this.likes = likes;
         this.dislikes = dislikes;
-        this.authorId = authorId;
+        this.authorId = userId;
         this.creationDate = creationDate;
     }
 

--- a/src/main/java/ua/rbolck/rader/entity/Post.java
+++ b/src/main/java/ua/rbolck/rader/entity/Post.java
@@ -1,5 +1,8 @@
 package ua.rbolck.rader.entity;
 
+import ua.rbolck.rader.dao.UserDAOI;
+import ua.rbolck.rader.dao.UserDAOImpl;
+
 import java.sql.Timestamp;
 
 public class Post {
@@ -9,6 +12,7 @@ public class Post {
     private String content;
     private int likes;
     private int dislikes;
+    private int authorId;
     private User author;
     private Timestamp creationDate;
 
@@ -19,6 +23,16 @@ public class Post {
         this.likes = likes;
         this.dislikes = dislikes;
         this.author = author;
+        this.creationDate = creationDate;
+    }
+
+    public Post(int id, String title, String content, int likes, int dislikes, int userId, Timestamp creationDate) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.likes = likes;
+        this.dislikes = dislikes;
+        this.authorId = authorId;
         this.creationDate = creationDate;
     }
 
@@ -66,7 +80,19 @@ public class Post {
         this.dislikes = dislikes;
     }
 
+    public int getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(int authorId) {
+        this.authorId = authorId;
+    }
+
     public User getAuthor() {
+        if (this.author == null) {
+            UserDAOI userDAO = new UserDAOImpl();
+            this.author = userDAO.get(this.authorId);
+        }
         return author;
     }
 


### PR DESCRIPTION
Basically, method PostDAO.get(int id) should not return object of related columns. It should return object post with filled author_id only.

Additional SQL query should be performed only if method Post.getAuthor() called.
